### PR TITLE
Exclude deleted .docx files from pandoc conversion

### DIFF
--- a/shell-script/pre-commit-git-diff-docx.sh
+++ b/shell-script/pre-commit-git-diff-docx.sh
@@ -103,8 +103,8 @@ cd `git rev-parse --show-toplevel`
 # delete temp file with list of Mardown files to amend commit
 rm -f .commit-amend-markdown
 
-# create a Markdown copy of every .docx file that is committed
-for file in `git diff --cached --name-only | grep \.docx`
+# create a Markdown copy of every .docx file that is committed, excluding deleted files
+for file in `git diff --cached --name-only --diff-filter=d | grep \.docx`
 do
     # name of Markdown file
     mdfile="${file%.docx}.md"
@@ -122,5 +122,16 @@ do
     # here, because that adds the files to the next commit, not to
     # this one
     echo "$mdfile" >> .commit-amend-markdown
+
+done
+
+# remove the Markdown copy of any file that is to be deleted from the repo
+for file in `git diff --cached --name-only --diff-filter=D | grep \.docx`
+do
+    # name of Markdown file
+    mdfile="${file%.docx}.md"
+    echo Removing Markdown copy of "$file"
+
+    rm "$mdfile"
 
 done


### PR DESCRIPTION
If you try to commit changes to your repo that include the deletion of a tracked `*.docx` file, pandoc will try to convert the (now nonexistent) file to `*.md`, and fail. Since the script executed by the pre-commit hook therefore returns an error, the commit will fail.

A simple workaround is to use the `--diff-filter=d` option, which will *exclude* any deleted files from being passed to pandoc. This creates a need to remove the associated `*.md` file, which I have added as a separate loop at the bottom.