### PR TITLE
Fix bug reading compressed metaimages with >8-bit data type

### DIFF
--- a/matlab/FileFormatToolbox/scimat_load.m
+++ b/matlab/FileFormatToolbox/scimat_load.m
@@ -287,12 +287,12 @@ switch lower(ext)
                     
                     warning('File did not provide CompressedDataSize. Trying to read to the end of file')
                     scimat.data = fread(fid, prod(sz) * nchannel, ...
-                        [data_type '=>' data_type]);
+                        'uint8=>uint8');
                     
                 else
                     
                     scimat.data = fread(fid, compressedSize, ...
-                        [data_type '=>' data_type]);
+                        'uint8=>uint8');
                     
                 end
 


### PR DESCRIPTION
An error occurred in zlib_decompress when loading metaimages with >8-bit data type (eg. doubles). Fix: Always read compressed metaimages as an 8-bit data type, since this is what is expected by the ZLIB decompressor. (Type casting is performed after decompression.)